### PR TITLE
Windows execution - fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clones-quality-agent",
-      "version": "2.0.12",
+      "version": "2.0.13",
       "license": "MIT",
       "dependencies": {
         "canvas": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clones-quality-agent",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
         "canvas": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clones-quality-agent",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "MIT",
       "dependencies": {
         "canvas": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "scripts": {
     "test": "bun test",
     "test:grading": "bun run scripts/test-grading.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "scripts": {
     "test": "bun test",
     "test:grading": "bun run scripts/test-grading.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "scripts": {
     "test": "bun test",
     "test:grading": "bun run scripts/test-grading.ts",

--- a/src/stages/extraction/video-extractor.ts
+++ b/src/stages/extraction/video-extractor.ts
@@ -25,14 +25,24 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
         windowsHide: true,
       });
 
-      if (result.status !== 0) return null;
-      if (!fs.existsSync(outputPath)) return null;
+      if (result.status !== 0) {
+        if (result.stderr) {
+          console.error(`[VideoExtractor] Failed to extract frame at ${timestamp}ms:`, result.stderr.toString());
+        }
+        return null;
+      }
+      
+      if (!fs.existsSync(outputPath)) {
+        console.error(`[VideoExtractor] Output file not created: ${outputPath}`);
+        return null;
+      }
 
       const imageBuffer = fs.readFileSync(outputPath);
       fs.unlinkSync(outputPath);
 
       return imageBuffer.toString('base64');
-    } catch {
+    } catch (error) {
+      console.error(`[VideoExtractor] Error extracting frame at ${timestamp}ms:`, error);
       return null;
     }
   }
@@ -61,6 +71,9 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
     }
 
     // Get video duration - use spawnSync to avoid ENOTCONN issues on Windows compiled binaries
+    console.log(`[VideoExtractor] Getting duration for video: ${videoPath}`);
+    console.log(`[VideoExtractor] Using ffprobe: ${this.ffprobePath}`);
+    
     const result = spawnSync(this.ffprobePath, [
       '-v', 'error',
       '-show_entries', 'format=duration',
@@ -73,11 +86,12 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
     });
 
     if (result.status !== 0 || !result.stdout) {
-      console.error('Failed to get video duration:', result.stderr);
+      console.error('[VideoExtractor] Failed to get video duration:', result.stderr);
       return events;
     }
 
     const stdout = result.stdout;
+    console.log(`[VideoExtractor] Video duration raw output: ${stdout.trim()}`);
 
     const durationStr = stdout.trim();
     const durationSecs = Math.floor(parseFloat(durationStr));

--- a/src/stages/extraction/video-extractor.ts
+++ b/src/stages/extraction/video-extractor.ts
@@ -1,4 +1,3 @@
-import { execSync } from 'child_process';
 import fs from 'node:fs';
 import path from 'path';
 import { PipelineStage, ProcessedEvent } from '../../shared/types';
@@ -14,15 +13,20 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
     const outputPath = path.join(this.dataDir, 'temp', `frame_${timestamp}.jpg`);
 
     try {
-      execSync(
-        `${this.ffmpegPath} -ss ${
-          timestamp / 1000
-        } -i "${videoPath}" -vframes 1 -y "${outputPath}"`,
-        {
-          stdio: ['pipe', 'pipe', 'pipe']
-        }
-      );
+      const proc = Bun.spawn([
+        this.ffmpegPath,
+        '-ss', (timestamp / 1000).toString(),
+        '-i', videoPath,
+        '-vframes', '1',
+        '-y', outputPath
+      ], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+      });
 
+      await proc.exited;
+      if (proc.exitCode !== 0) return null;
       if (!fs.existsSync(outputPath)) return null;
 
       const imageBuffer = fs.readFileSync(outputPath);
@@ -58,10 +62,28 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
     }
 
     // Get video duration
-    const durationStr = execSync(
-      `${this.ffprobePath} -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${videoPath}"`,
-      { encoding: 'utf-8' }
-    );
+    const proc = Bun.spawn([
+      this.ffprobePath,
+      '-v', 'error',
+      '-show_entries', 'format=duration',
+      '-of', 'default=noprint_wrappers=1:nokey=1',
+      videoPath
+    ], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      stdin: 'ignore',
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    if (proc.exitCode !== 0 || !stdout) {
+      const stderr = await new Response(proc.stderr).text();
+      console.error('Failed to get video duration:', stderr);
+      return events;
+    }
+
+    const durationStr = stdout.trim();
     const durationSecs = Math.floor(parseFloat(durationStr));
     const durationMs = durationSecs * 1000;
 

--- a/src/stages/extraction/video-extractor.ts
+++ b/src/stages/extraction/video-extractor.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'path';
 import { PipelineStage, ProcessedEvent } from '../../shared/types';
+import { spawnSync } from 'node:child_process';
 
 export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
   constructor(
@@ -13,20 +14,18 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
     const outputPath = path.join(this.dataDir, 'temp', `frame_${timestamp}.jpg`);
 
     try {
-      const proc = Bun.spawn([
-        this.ffmpegPath,
+      // Use spawnSync instead of Bun.spawn to avoid ENOTCONN issues on Windows compiled binaries
+      const result = spawnSync(this.ffmpegPath, [
         '-ss', (timestamp / 1000).toString(),
         '-i', videoPath,
         '-vframes', '1',
         '-y', outputPath
       ], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-        stdin: 'ignore',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
       });
 
-      await proc.exited;
-      if (proc.exitCode !== 0) return null;
+      if (result.status !== 0) return null;
       if (!fs.existsSync(outputPath)) return null;
 
       const imageBuffer = fs.readFileSync(outputPath);
@@ -61,27 +60,24 @@ export class VideoExtractor implements PipelineStage<string, ProcessedEvent[]> {
       fs.mkdirSync(tempDir, { recursive: true });
     }
 
-    // Get video duration
-    const proc = Bun.spawn([
-      this.ffprobePath,
+    // Get video duration - use spawnSync to avoid ENOTCONN issues on Windows compiled binaries
+    const result = spawnSync(this.ffprobePath, [
       '-v', 'error',
       '-show_entries', 'format=duration',
       '-of', 'default=noprint_wrappers=1:nokey=1',
       videoPath
     ], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-      stdin: 'ignore',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+      encoding: 'utf-8',
     });
 
-    const stdout = await new Response(proc.stdout).text();
-    await proc.exited;
-
-    if (proc.exitCode !== 0 || !stdout) {
-      const stderr = await new Response(proc.stderr).text();
-      console.error('Failed to get video duration:', stderr);
+    if (result.status !== 0 || !result.stdout) {
+      console.error('Failed to get video duration:', result.stderr);
       return events;
     }
+
+    const stdout = result.stdout;
 
     const durationStr = stdout.trim();
     const durationSecs = Math.floor(parseFloat(durationStr));


### PR DESCRIPTION
This pull request updates the video extraction pipeline to use Bun's process management instead of Node's `execSync`, improving performance and reliability. The main changes focus on replacing synchronous child process calls with asynchronous Bun APIs, enhancing error handling, and modernizing the codebase.

### Migration to Bun process APIs

* Replaced all usages of `execSync` for running `ffmpeg` and `ffprobe` with Bun's `spawn` API, allowing asynchronous execution and better resource management in `video-extractor.ts`. [[1]](diffhunk://#diff-3b54d63bb2cefd29ecd1bf0a7e31fe39a73b3fe944fea4819024b62706137b72L17-R29) [[2]](diffhunk://#diff-3b54d63bb2cefd29ecd1bf0a7e31fe39a73b3fe944fea4819024b62706137b72L61-R86)
* Improved error handling by checking process exit codes and logging errors from `ffprobe` when video duration extraction fails.

### Codebase modernization

* Removed the import of `execSync` from `child_process`, as it is no longer needed after migrating to Bun APIs in `video-extractor.ts`.

### Package version update

* Bumped the package version from `2.0.12` to `2.0.13` in `package.json` to reflect these changes.