### PR TITLE
Publish builds to tigris

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,10 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
-      - name: Upload to Tigris
-        run: ./scripts/upload_to_tigris.sh
+      - name: Make script executable and upload to Tigris
+        run: |
+          chmod +x ./scripts/upload_to_tigris.sh
+          ./scripts/upload_to_tigris.sh
         env:
           TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}
           TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
           # Convert Windows line endings to Unix
           sed -i 's/\r$//' scripts/upload_to_tigris.sh
           chmod +x scripts/upload_to_tigris.sh
+          echo "=== Debug: target directory structure ==="
+          ls -la target/
+          echo "=== Debug: artifacts directory structure ==="
+          ls -la artifacts/
           bash scripts/upload_to_tigris.sh
         env:
           TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Make script executable and upload to Tigris
         run: |
-          ls -la scripts/
+          # Convert Windows line endings to Unix
+          sed -i 's/\r$//' scripts/upload_to_tigris.sh
           chmod +x scripts/upload_to_tigris.sh
           bash scripts/upload_to_tigris.sh
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,9 @@ jobs:
 
       - name: Make script executable and upload to Tigris
         run: |
-          chmod +x ./scripts/upload_to_tigris.sh
-          ./scripts/upload_to_tigris.sh
+          ls -la scripts/
+          chmod +x scripts/upload_to_tigris.sh
+          bash scripts/upload_to_tigris.sh
         env:
           TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}
           TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,33 +33,11 @@ jobs:
           path: target/
           compression-level: 0
 
-  release:
+  upload-to-tigris:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # This is important for getting all tags
-
-      - name: Get version from package.json
-        id: get_version
-        run: |
-          version=$(jq -r .version package.json)
-          echo "Version from package.json: $version"
-          new_tag="v$version"
-          echo "NEW_TAG=$new_tag" >> $GITHUB_ENV
-          echo "Tag for release will be: $new_tag"
-
-      - name: Delete existing release if it exists
-        run: |
-          if gh release view ${{ env.NEW_TAG }} &> /dev/null; then
-            echo "Deleting existing release ${{ env.NEW_TAG }}"
-            gh release delete ${{ env.NEW_TAG }} --yes --cleanup-tag
-          else
-            echo "No existing release found for ${{ env.NEW_TAG }}"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -69,16 +47,22 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts/
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.NEW_TAG }}
-          name: Release ${{ env.NEW_TAG }}
-          draft: false
-          prerelease: false
-          files: artifacts/artifact/*
-          generate_release_notes: true
-          fail_on_unmatched_files: false
-          make_latest: true
+      - name: Prepare target directory
+        run: |
+          mkdir -p target
+          cp -r artifacts/artifact/* target/
+
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Upload to Tigris
+        run: ./scripts/upload_to_tigris.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TIGRIS_ACCESS_KEY_ID: ${{ secrets.TIGRIS_ACCESS_KEY_ID }}
+          TIGRIS_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_SECRET_ACCESS_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clones-quality-agent",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "license": "MIT",
       "dependencies": {
         "canvas": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.12",
+  "version": "2.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clones-quality-agent",
-      "version": "2.0.12",
+      "version": "2.0.20",
       "license": "MIT",
       "dependencies": {
         "canvas": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.12",
+  "version": "2.0.20",
   "scripts": {
     "test": "bun test",
     "test:grading": "bun run scripts/test-grading.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clones-quality-agent",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "scripts": {
     "test": "bun test",
     "test:grading": "bun run scripts/test-grading.ts",

--- a/scripts/upload_to_tigris.sh
+++ b/scripts/upload_to_tigris.sh
@@ -94,21 +94,25 @@ upload_binaries() {
     
     log_info "Uploading binaries from: $target_dir"
     
-    # Upload each platform binary directly to cqa folder
-    for platform_dir in "$target_dir"/*; do
-        if [ -d "$platform_dir" ]; then
-            local platform=$(basename "$platform_dir")
-            log_info "Processing platform: $platform"
+    # Upload each binary file directly from target directory
+    for binary_file in "$target_dir"/*; do
+        if [ -f "$binary_file" ] && [[ ! "$binary_file" =~ \.(json|md|txt)$ ]]; then
+            local file_name=$(basename "$binary_file")
             
-            # Find binary file in platform directory
-            for binary_file in "$platform_dir"/*; do
-                if [ -f "$binary_file" ] && [[ ! "$binary_file" =~ \.(json|md|txt)$ ]]; then
-                    local file_name=$(basename "$binary_file")
-                    
-                    # Upload directly to cqa folder
-                    upload_file "$binary_file" "cqa/$file_name" "$version" "$platform"
-                fi
-            done
+            # Determine platform from filename
+            local platform="unknown"
+            if [[ "$file_name" =~ linux ]]; then
+                platform="linux"
+            elif [[ "$file_name" =~ macos ]]; then
+                platform="macos"
+            elif [[ "$file_name" =~ win ]]; then
+                platform="windows"
+            fi
+            
+            log_info "Processing file: $file_name (platform: $platform)"
+            
+            # Upload directly to cqa folder
+            upload_file "$binary_file" "cqa/$file_name" "$version" "$platform"
         fi
     done
     

--- a/scripts/upload_to_tigris.sh
+++ b/scripts/upload_to_tigris.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "🚀 Uploading Clones Quality Agent binaries to Tigris"
+
+# Configuration
+export TIGRIS_BUCKET="clones-desktop-release-prod"
+export BUCKET_URL="https://releases.clones-ai.com"
+export TIGRIS_ENDPOINT="https://fly.storage.tigris.dev"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+log_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+log_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+# Get app version from package.json
+get_app_version() {
+    if [ ! -f "package.json" ]; then
+        log_error "package.json not found"
+        exit 1
+    fi
+    
+    local version=$(jq -r .version package.json)
+    
+    if [ -z "$version" ] || [ "$version" = "null" ]; then
+        log_error "Could not extract version from package.json"
+        exit 1
+    fi
+    
+    echo "$version"
+}
+
+# Upload file to Tigris
+upload_file() {
+    local file_path="$1"
+    local s3_key="$2"
+    local version="$3"
+    local platform="$4"
+    
+    if [ ! -f "$file_path" ]; then
+        log_error "File not found: $file_path"
+        return 1
+    fi
+    
+    local file_size=$(stat -f%z "$file_path" 2>/dev/null || stat -c%s "$file_path")
+    local file_name=$(basename "$file_path")
+    local upload_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    
+    log_info "Uploading $file_name (${file_size} bytes) to $s3_key..."
+    
+    # Upload to S3-compatible Tigris storage with metadata
+    aws s3 cp "$file_path" \
+        "s3://${TIGRIS_BUCKET}/${s3_key}" \
+        --endpoint-url "$TIGRIS_ENDPOINT" \
+        --region auto \
+        --metadata "version=$version,platform=$platform,uploaded=$upload_date" \
+        --content-type "application/octet-stream" \
+        --no-progress
+    
+    log_success "Uploaded: $file_name → $s3_key"
+    echo "  📄 Direct URL: ${BUCKET_URL}/${s3_key}"
+}
+
+
+# Upload all binaries
+upload_binaries() {
+    local version="$1"
+    local target_dir="target"
+    
+    if [ ! -d "$target_dir" ]; then
+        log_error "Target directory not found: $target_dir"
+        log_info "Run 'bun run build' first"
+        exit 1
+    fi
+    
+    log_info "Uploading binaries from: $target_dir"
+    
+    # Upload each platform binary directly to cqa folder
+    for platform_dir in "$target_dir"/*; do
+        if [ -d "$platform_dir" ]; then
+            local platform=$(basename "$platform_dir")
+            log_info "Processing platform: $platform"
+            
+            # Find binary file in platform directory
+            for binary_file in "$platform_dir"/*; do
+                if [ -f "$binary_file" ] && [[ ! "$binary_file" =~ \.(json|md|txt)$ ]]; then
+                    local file_name=$(basename "$binary_file")
+                    
+                    # Upload directly to cqa folder
+                    upload_file "$binary_file" "cqa/$file_name" "$version" "$platform"
+                fi
+            done
+        fi
+    done
+    
+}
+
+# Check prerequisites
+check_prerequisites() {
+    # Check AWS CLI
+    if ! command -v aws &> /dev/null; then
+        log_error "AWS CLI not found. Please install it."
+        exit 1
+    fi
+    
+    # Check jq
+    if ! command -v jq &> /dev/null; then
+        log_error "jq not found. Please install it."
+        exit 1
+    fi
+    
+    # Check Tigris credentials
+    if [ -z "${TIGRIS_ACCESS_KEY_ID:-}" ]; then
+        log_error "TIGRIS_ACCESS_KEY_ID not set"
+        log_info "Set it as environment variable or in .env file"
+        exit 1
+    fi
+    
+    if [ -z "${TIGRIS_SECRET_ACCESS_KEY:-}" ]; then
+        log_error "TIGRIS_SECRET_ACCESS_KEY not set" 
+        log_info "Set it as environment variable or in .env file"
+        exit 1
+    fi
+    
+    # Configure AWS environment for Tigris
+    export AWS_ACCESS_KEY_ID="$TIGRIS_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$TIGRIS_SECRET_ACCESS_KEY"
+    export AWS_ENDPOINT_URL="$TIGRIS_ENDPOINT"
+    export AWS_REGION="auto"
+}
+
+# Load environment variables from .env file if it exists
+load_env() {
+    if [ -f ".env" ]; then
+        log_info "Loading environment variables from .env..."
+        export $(grep -v '^#' .env | xargs)
+        log_success "Environment variables loaded"
+    fi
+}
+
+# Main execution
+main() {
+    echo "🔗 Clones Quality Agent - Tigris Upload Script"
+    echo "=============================================="
+    
+    load_env
+    check_prerequisites
+    
+    local version=$(get_app_version)
+    log_info "App version: $version"
+    
+    upload_binaries "$version"
+    
+    echo ""
+    log_success "🎉 Upload completed successfully!"
+    log_info "Files available at:"
+    echo "  📦 Builds: ${BUCKET_URL}/cqa/"
+}
+
+# Run if executed directly
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi

--- a/scripts/upload_to_tigris.sh
+++ b/scripts/upload_to_tigris.sh
@@ -109,10 +109,21 @@ upload_binaries() {
                 platform="windows"
             fi
             
-            log_info "Processing file: $file_name (platform: $platform)"
+            # Add version to filename
+            local base_name="${file_name%.*}"
+            local extension="${file_name##*.}"
+            local versioned_name
             
-            # Upload directly to cqa folder
-            upload_file "$binary_file" "cqa/$file_name" "$version" "$platform"
+            if [[ "$file_name" == *.* ]]; then
+                versioned_name="${base_name}-v${version}.${extension}"
+            else
+                versioned_name="${base_name}-v${version}"
+            fi
+            
+            log_info "Processing file: $file_name -> $versioned_name (platform: $platform)"
+            
+            # Upload to cqa folder with versioned name
+            upload_file "$binary_file" "cqa/$versioned_name" "$version" "$platform"
         fi
     done
     


### PR DESCRIPTION
This pull request updates the release workflow to replace the GitHub release step with a new process that uploads release binaries directly to Tigris storage. It introduces a new upload script, updates the workflow configuration, and bumps the application version. The main themes are release automation changes and infrastructure integration.

**Release workflow changes:**

* Replaces the `release` job in `.github/workflows/release.yml` with a new `upload-to-tigris` job, removing steps for creating and deleting GitHub releases and adding steps to prepare artifacts, install dependencies, and upload to Tigris. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-L62) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L72-R68)

**Infrastructure integration:**

* Adds a new script `scripts/upload_to_tigris.sh` that handles uploading binaries to Tigris, including environment setup, version extraction, file upload logic, and output formatting.